### PR TITLE
fix: remove unused session variable in test

### DIFF
--- a/tests/unit/reading.service-more.spec.ts
+++ b/tests/unit/reading.service-more.spec.ts
@@ -49,7 +49,7 @@ describe('ReadingService extra coverage', () => {
       { text: '.', prefix: '', orp: '.', suffix: '', displayTime: 100, isKeyTerm: false, isPunctuation: true, isFunctionWord: false, isImage: false },
       { text: 'Next', prefix: 'N', orp: 'e', suffix: 'xt', displayTime: 100, isKeyTerm: false, isPunctuation: false, isFunctionWord: false, isImage: false },
     ]
-    const session = svc.startSession('art')
+    svc.startSession('art')
     // Jump to end
     svc.jumpToEnd()
     expect((svc as any)['session'].currentWordIndex).toBe(4)


### PR DESCRIPTION
Fixes TypeScript build error that was preventing deployment.

The `session` variable was declared but never used, causing the build to fail.