### PR TITLE
fix: apply cached WPM to playback speed on initial load

### DIFF
--- a/src/reading.ts
+++ b/src/reading.ts
@@ -176,6 +176,10 @@ class ReadingApp {
     // Update header
     this.articleTitleElement.textContent = this.article.title
 
+    // Apply current settings to reading service before processing text
+    const currentSettings = this.readingControls.getSettings()
+    this.readingService.updateSettings(currentSettings)
+
     // Process article text for RSVP
     const words = this.readingService.processText(this.article.cleanedContent, this.article.url)
     


### PR DESCRIPTION
Fixes issue where the WPM indicator displayed the correct cached value but the actual playback speed used the default 250 WPM.

## Root Cause
The cached WPM value was being loaded from localStorage and displayed in the UI, but the ReadingService wasn't receiving these settings before processing text.

## Solution  
Added `readingService.updateSettings()` call with the loaded settings before `processText()` in `initializeReading()`.

## Testing
- ✅ All unit tests passing (96 tests)
- ✅ All BDD tests passing (24 scenarios)
- ✅ E2E tests passing
- ✅ Prototype tested at https://d3c1b15e.gleaned-covid.pages.dev

Closes #25