### PR TITLE
fix(ui): allow scrolling on ingest page for iPhone

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
           node-version: '20'
           cache: 'npm'
       - run: npm ci
+      - run: npm run build
       - name: Install Vitest coverage provider (no-save)
         run: npm i -D @vitest/coverage-v8 --no-save
       - name: Unit tests (Vitest)

--- a/ingest.html
+++ b/ingest.html
@@ -22,8 +22,6 @@
             display: flex;
             flex-direction: column;
             min-height: 100vh;
-            max-height: 100vh;
-            overflow: hidden;
         }
 
         .main-header {
@@ -34,15 +32,16 @@
             max-width: 800px;
             margin: 0 auto;
             padding: 0.5rem;
+            padding-top: 1rem;
             text-align: center;
             flex: 1;
-            overflow: hidden;
+            overflow-y: auto;
             display: flex;
             flex-direction: column;
-            justify-content: center;
+            justify-content: flex-start;
             min-height: 0;
-            /* Keep content clear of the footer */
-            padding-bottom: var(--footer-height, 56px);
+            /* Keep content clear of the footer and iPhone home indicator */
+            padding-bottom: calc(env(safe-area-inset-bottom) + var(--footer-height, 56px) + 1rem);
         }
 
         #support-footer {

--- a/tests/features/ingest-page-fix.spec.ts
+++ b/tests/features/ingest-page-fix.spec.ts
@@ -26,6 +26,29 @@ describe('Ingest Page Fix', () => {
     })
   })
 
+  it('should not have overflow hidden on the body in ingest page styles', () => {
+    // The ingest page inline styles must NOT set overflow: hidden on body,
+    // otherwise iPhone users cannot scroll and buttons get covered by the footer.
+    const fs = require('fs')
+    const path = require('path')
+    const html = fs.readFileSync(path.resolve(__dirname, '../../ingest.html'), 'utf-8')
+
+    // Extract inline <style> content
+    const styleMatch = html.match(/<style>([\s\S]*?)<\/style>/)
+    expect(styleMatch).not.toBeNull()
+    const styleContent = styleMatch![1]
+
+    // Extract the body rule
+    const bodyRuleMatch = styleContent.match(/body\s*\{([^}]*)\}/)
+    expect(bodyRuleMatch).not.toBeNull()
+    const bodyRule = bodyRuleMatch![1]
+
+    // Body must not have overflow: hidden
+    expect(bodyRule).not.toMatch(/overflow\s*:\s*hidden/)
+    // Body must not have max-height: 100vh (prevents scrolling)
+    expect(bodyRule).not.toMatch(/max-height\s*:\s*100vh/)
+  })
+
   it('should store articles from ingest page with unique keys', () => {
     // Mock processed articles from ingest page
     const article1 = {


### PR DESCRIPTION
Copybara import of the project:

--
e0f949806bc8ed1a534b6160c809be230307405e by Copybara <noreply@copybara.com>:

fix(ui): allow scrolling on ingest page for iPhone; add build step to CI

Remove overflow:hidden and max-height:100vh from body so iPhone users
can scroll. Adjust ingest-container for flex-start alignment and safe-area
padding. Add npm run build to CI so page-content tests find dist/.

Closes cog32/gleaned#32

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

Closes #32
